### PR TITLE
Add logFixMessages argument to brokerage constructor

### DIFF
--- a/QuantConnect.TradingTechnologies/Fix/FixInstance.cs
+++ b/QuantConnect.TradingTechnologies/Fix/FixInstance.cs
@@ -32,14 +32,14 @@ namespace QuantConnect.TradingTechnologies.Fix
                         .All(session => session != null && session.IsLoggedOn);
         }
 
-        public FixInstance(IFixProtocolDirector protocolDirector, FixConfiguration fixConfiguration)
+        public FixInstance(IFixProtocolDirector protocolDirector, FixConfiguration fixConfiguration, bool logFixMessages)
         {
             _protocolDirector = protocolDirector ?? throw new ArgumentNullException(nameof(protocolDirector));
 
             var settings = fixConfiguration.GetSessionSettings();
 
             var storeFactory = new FileStoreFactory(settings);
-            var logFactory = new QuickFixLogFactory();
+            var logFactory = new QuickFixLogFactory(logFixMessages);
             _acceptor = new SocketInitiator(this, storeFactory, settings, logFactory, protocolDirector.MessageFactory);
         }
 

--- a/QuantConnect.TradingTechnologies/Fix/LogFactory/QuickFixLogFactory.cs
+++ b/QuantConnect.TradingTechnologies/Fix/LogFactory/QuickFixLogFactory.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using QuantConnect.Configuration;
 using QuickFix;
 
 namespace QuantConnect.TradingTechnologies.Fix.LogFactory
@@ -13,23 +12,31 @@ namespace QuantConnect.TradingTechnologies.Fix.LogFactory
     public class QuickFixLogFactory : ILogFactory
     {
         private static readonly ConcurrentDictionary<SessionID, ILog> Loggers = new ConcurrentDictionary<SessionID, ILog>();
+        private readonly bool _logFixMessages;
+
+        public QuickFixLogFactory(bool logFixMessages)
+        {
+            _logFixMessages = logFixMessages;
+        }
 
         public ILog Create(SessionID sessionId)
         {
-            return Loggers.GetOrAdd(sessionId, s => new QuickFixLogger(s));
+            return Loggers.GetOrAdd(sessionId, s => new QuickFixLogger(s, _logFixMessages));
         }
     }
 
     public class QuickFixLogger : ILog
     {
-        private readonly bool _fixLoggingEnabled = Config.GetBool("tt-log-fix-messages");
+        private readonly bool _fixLoggingEnabled;
 
-        public QuickFixLogger(SessionID sessionId)
+        public QuickFixLogger(SessionID sessionId, bool logFixMessages)
         {
             if (sessionId == null)
             {
                 throw new ArgumentNullException(nameof(sessionId));
             }
+
+            _fixLoggingEnabled = logFixMessages;
         }
 
         public void Clear() { }

--- a/QuantConnect.TradingTechnologies/TradingTechnologiesBrokerage.cs
+++ b/QuantConnect.TradingTechnologies/TradingTechnologiesBrokerage.cs
@@ -43,7 +43,7 @@ namespace QuantConnect.TradingTechnologies
         private readonly TradingTechnologiesSymbolMapper _symbolMapper;
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
 
-        public TradingTechnologiesBrokerage(IAlgorithm algorithm, LiveNodePacket job, IOrderProvider orderProvider, IDataAggregator aggregator, FixConfiguration fixConfiguration)
+        public TradingTechnologiesBrokerage(IAlgorithm algorithm, LiveNodePacket job, IOrderProvider orderProvider, IDataAggregator aggregator, FixConfiguration fixConfiguration, bool logFixMessages)
             : base("TradingTechnologies")
         {
             _algorithm = algorithm;
@@ -66,7 +66,7 @@ namespace QuantConnect.TradingTechnologies
 
             var fixProtocolDirector = new TTFixProtocolDirector(_symbolMapper, fixConfiguration, _fixMarketDataController, _fixBrokerageController);
 
-            _fixInstance = new FixInstance(fixProtocolDirector, fixConfiguration);
+            _fixInstance = new FixInstance(fixProtocolDirector, fixConfiguration, logFixMessages);
         }
 
         /// <summary>

--- a/QuantConnect.TradingTechnologies/TradingTechnologiesBrokerageFactory.cs
+++ b/QuantConnect.TradingTechnologies/TradingTechnologiesBrokerageFactory.cs
@@ -57,7 +57,9 @@ namespace QuantConnect.TradingTechnologies
             { "tt-order-routing-port", Config.Get("tt-order-routing-port") },
 
             { "tt-initial-cash-amount", Config.Get("tt-initial-cash-amount") },
-            { "tt-initial-cash-currency", Config.Get("tt-initial-cash-currency") }
+            { "tt-initial-cash-currency", Config.Get("tt-initial-cash-currency") },
+
+            { "tt-log-fix-messages", Config.Get("tt-log-fix-messages") }
         };
 
         /// <summary>
@@ -98,6 +100,8 @@ namespace QuantConnect.TradingTechnologies
                 OrderRoutingPort = Read<string>(job.BrokerageData, "tt-order-routing-port", errors)
             };
 
+            var logFixMessages = Read<bool>(job.BrokerageData, "tt-log-fix-messages", errors);
+
             if (errors.Count != 0)
             {
                 // if we had errors then we can't create the instance
@@ -109,7 +113,8 @@ namespace QuantConnect.TradingTechnologies
                 job,
                 algorithm.Transactions,
                 Composer.Instance.GetExportedValueByTypeName<IDataAggregator>(Config.Get("data-aggregator", "QuantConnect.Lean.Engine.DataFeeds.AggregationManager")),
-                fixConfiguration);
+                fixConfiguration,
+                logFixMessages);
 
             Composer.Instance.AddPart<IDataQueueHandler>(instance);
 

--- a/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
+++ b/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
@@ -836,7 +836,7 @@ namespace QuantConnect.TradingTechnologiesTests
 
         private TradingTechnologiesBrokerage CreateBrokerage()
         {
-            return new TradingTechnologiesBrokerage(_algorithm, _job, _orderProvider, _aggregationManager, _fixConfiguration);
+            return new TradingTechnologiesBrokerage(_algorithm, _job, _orderProvider, _aggregationManager, _fixConfiguration, true);
         }
     }
 }


### PR DESCRIPTION
- Allows us to have Fix messages logged in QC cloud syslogs for easier debugging/troubleshooting 