### PR TITLE
Feature Include HandlInst when placing an order

### DIFF
--- a/QuantConnect.TradingTechnologies/TT/TTOrderRoutingSessionHandler.cs
+++ b/QuantConnect.TradingTechnologies/TT/TTOrderRoutingSessionHandler.cs
@@ -56,7 +56,7 @@ namespace QuantConnect.TradingTechnologies.TT
             var securityType = new QuantConnect.Fix.TT.FIX44.Fields.SecurityType(_symbolMapper.GetBrokerageProductType(order.Symbol.SecurityType));
 
             var displayFactor = _symbolMapper.GetDisplayFactor(order.Symbol);
-            var orderPropertiesHandleInstruc = (order.Properties as TradingTechnologiesOrderProperties)?.HandleInstruction;
+            var orderPropertiesHandleInstruction = (order.Properties as TradingTechnologiesOrderProperties)?.HandleInstruction;
 
             var ttOrder = new NewOrderSingle
             {
@@ -80,9 +80,9 @@ namespace QuantConnect.TradingTechnologies.TT
                 OrderOrigination = new OrderOrigination(OrderOrigination.ORDER_RECEIVED_FROM_DIRECT_OR_SPONSORED_ACCESS_CUSTOMER)
             };
 
-            if (orderPropertiesHandleInstruc != null)
+            if (orderPropertiesHandleInstruction != null)
             {
-                ttOrder.HandlInst = new HandlInst((char)orderPropertiesHandleInstruc);
+                ttOrder.HandlInst = new HandlInst((char)orderPropertiesHandleInstruction);
             }
 
             if (order.Symbol.SecurityType == SecurityType.Future)

--- a/QuantConnect.TradingTechnologies/TT/TTOrderRoutingSessionHandler.cs
+++ b/QuantConnect.TradingTechnologies/TT/TTOrderRoutingSessionHandler.cs
@@ -56,6 +56,7 @@ namespace QuantConnect.TradingTechnologies.TT
             var securityType = new QuantConnect.Fix.TT.FIX44.Fields.SecurityType(_symbolMapper.GetBrokerageProductType(order.Symbol.SecurityType));
 
             var displayFactor = _symbolMapper.GetDisplayFactor(order.Symbol);
+            var orderPropertiesHandleInstruc = (order.Properties as TradingTechnologiesOrderProperties)?.HandleInstruction;
 
             var ttOrder = new NewOrderSingle
             {
@@ -78,6 +79,11 @@ namespace QuantConnect.TradingTechnologies.TT
                 CustOrderHandlingInst = new CustOrderHandlingInst(CustOrderHandlingInst.ELECTRONIC),
                 OrderOrigination = new OrderOrigination(OrderOrigination.ORDER_RECEIVED_FROM_DIRECT_OR_SPONSORED_ACCESS_CUSTOMER)
             };
+
+            if (orderPropertiesHandleInstruc != null)
+            {
+                ttOrder.HandlInst = new HandlInst((char)orderPropertiesHandleInstruc);
+            }
 
             if (order.Symbol.SecurityType == SecurityType.Future)
             {

--- a/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
+++ b/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
@@ -13,6 +13,8 @@ using QuantConnect.Algorithm;
 using QuantConnect.Configuration;
 using QuantConnect.Data;
 using QuantConnect.Data.Market;
+using QuantConnect.Fix.TT.FIX44.Fields;
+using QuantConnect.Fix.TT.FIX44.Messages;
 using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
@@ -824,6 +826,15 @@ namespace QuantConnect.TradingTechnologiesTests
             fixInstance.OnLogon(sessionId);
 
             fixInstance.Terminate();
+        }
+
+        [TestCase(TradingTechnologiesOrderProperties.AutomatedExecutionOrderPrivate)]
+        public void OrderCanDefineHandleInstruction(char handleInstruction)
+        {
+            var ttOrderProperties = new TradingTechnologiesOrderProperties() { HandleInstruction = handleInstruction };
+            var ttOrder = new NewOrderSingle() { HandlInst = new HandlInst((char)ttOrderProperties.HandleInstruction) };
+            Assert.AreEqual(handleInstruction, ttOrder.HandlInst.getValue());
+
         }
 
         private readonly Dictionary<Symbol, decimal> _bidPrices = new Dictionary<Symbol, decimal>

--- a/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
+++ b/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
@@ -829,12 +829,13 @@ namespace QuantConnect.TradingTechnologiesTests
         }
 
         [TestCase(TradingTechnologiesOrderProperties.AutomatedExecutionOrderPrivate)]
+        [TestCase(TradingTechnologiesOrderProperties.AutomatedExecutionOrderPublic)]
+        [TestCase(TradingTechnologiesOrderProperties.ManualOrder)]
         public void OrderCanDefineHandleInstruction(char handleInstruction)
         {
             var ttOrderProperties = new TradingTechnologiesOrderProperties() { HandleInstruction = handleInstruction };
             var ttOrder = new NewOrderSingle() { HandlInst = new HandlInst((char)ttOrderProperties.HandleInstruction) };
             Assert.AreEqual(handleInstruction, ttOrder.HandlInst.getValue());
-
         }
 
         private readonly Dictionary<Symbol, decimal> _bidPrices = new Dictionary<Symbol, decimal>


### PR DESCRIPTION
So far, when placing a TT order, we're not taking into account the `HandleInstruction` property. With this change, we take into account this property when placing a TT order, extracting it from the `order.Properties`. In LEAN, we have simultaneously created a file named `TradingTechnologiesOrderProperties` with a property called `HandleInstruction` of nullable `char` type, so that the user can create the TT order properties and assign them to `DefaultOrderProperties` when creating a LEAN algo. Finally, unit tests have been made to assert it works with different handle instructions defined by TT (see https://library.tradingtechnologies.com/tt-fix/order-routing/Msg_NewOrderSingle_D.html)