### PR TITLE
Use Notes when placing order

### DIFF
--- a/QuantConnect.TradingTechnologies/TT/TTOrderRoutingSessionHandler.cs
+++ b/QuantConnect.TradingTechnologies/TT/TTOrderRoutingSessionHandler.cs
@@ -56,7 +56,6 @@ namespace QuantConnect.TradingTechnologies.TT
             var securityType = new QuantConnect.Fix.TT.FIX44.Fields.SecurityType(_symbolMapper.GetBrokerageProductType(order.Symbol.SecurityType));
 
             var displayFactor = _symbolMapper.GetDisplayFactor(order.Symbol);
-            var orderPropertiesHandleInstruction = (order.Properties as TradingTechnologiesOrderProperties)?.HandleInstruction;
 
             var ttOrder = new NewOrderSingle
             {
@@ -79,9 +78,21 @@ namespace QuantConnect.TradingTechnologies.TT
                 OrderOrigination = new OrderOrigination(OrderOrigination.ORDER_RECEIVED_FROM_DIRECT_OR_SPONSORED_ACCESS_CUSTOMER)
             };
 
-            if (orderPropertiesHandleInstruction != null)
+            var orderProperties = (order.Properties as TradingTechnologiesOrderProperties);
+            if (orderProperties != null)
             {
-                ttOrder.HandlInst = new HandlInst((char)orderPropertiesHandleInstruction);
+                var orderPropertiesHandleInstruction = orderProperties.HandleInstruction;
+                var orderPropertiesNotes = orderProperties.Notes;
+
+                if (orderPropertiesHandleInstruction != null)
+                {
+                    ttOrder.HandlInst = new HandlInst((char)orderPropertiesHandleInstruction);
+                }
+
+                if (!orderPropertiesNotes.IsNullOrEmpty())
+                {
+                    ttOrder.Text = new Text(orderPropertiesNotes);
+                }
             }
 
             if (order.Symbol.SecurityType == SecurityType.Future)

--- a/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
+++ b/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
@@ -861,7 +861,6 @@ namespace QuantConnect.TradingTechnologiesTests
         [TestCase("Example text")]
         [TestCase("")]
         [TestCase(null)]
-        [TestCase("t")]
         public void OrderCanDefineNotes(string notes)
         {
             var ttOrderProperties = new TradingTechnologiesOrderProperties() { Notes = notes };

--- a/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
+++ b/QuantConnect.TradingTechnologiesTests/TradingTechnologiesBrokerageTests.cs
@@ -858,6 +858,17 @@ namespace QuantConnect.TradingTechnologiesTests
             Assert.AreEqual(handleInstruction, ttOrder.HandlInst.getValue());
         }
 
+        [TestCase("Example text")]
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("t")]
+        public void OrderCanDefineNotes(string notes)
+        {
+            var ttOrderProperties = new TradingTechnologiesOrderProperties() { Notes = notes };
+            var ttOrder = new NewOrderSingle() { Text = new Text(ttOrderProperties.Notes) };
+            Assert.AreEqual(notes, ttOrder.Text.getValue());
+        }
+
         private readonly Dictionary<Symbol, decimal> _bidPrices = new Dictionary<Symbol, decimal>
         {
             { _symbolEs, 4470m },


### PR DESCRIPTION
With this change the notes (https://www.onixs.biz/fix-dictionary/4.4/tagNum_58.html) defined by the user in the order properties will be taken into account when placing a TT order. Unit tests were made to assert the new field in the `FixOrderProperties` was working as expected.


See https://github.com/QuantConnect/Lean/pull/7491