### PR TITLE
Use Globals for credentials access for subscription validation

### DIFF
--- a/QuantConnect.TradingTechnologies/TradingTechnologiesBrokerage.cs
+++ b/QuantConnect.TradingTechnologies/TradingTechnologiesBrokerage.cs
@@ -341,10 +341,10 @@ namespace QuantConnect.TradingTechnologies
         {
             try
             {
-                var productId = 64;
-                var userId = Config.GetInt("job-user-id");
-                var token = Config.Get("api-access-token");
-                var organizationId = Config.Get("job-organization-id", null);
+                const int productId = 64;
+                var userId = Globals.UserId;
+                var token = Globals.UserToken;
+                var organizationId = Globals.OrganizationID;
                 // Verify we can authenticate with this user and token
                 var api = new ApiConnection(userId, token);
                 if (!api.Connected)


### PR DESCRIPTION
Use Globals for credentials access for subscription validation.
This follows https://github.com/QuantConnect/Lean/pull/7796